### PR TITLE
Support for Showing and Hiding CVV Field in Scan View

### DIFF
--- a/iphone/Classes/ComLikelysoftCardioModule.m
+++ b/iphone/Classes/ComLikelysoftCardioModule.m
@@ -97,6 +97,15 @@
     
     CardIOPaymentViewController *scanViewController = [[[CardIOPaymentViewController alloc] initWithPaymentDelegate:self] autorelease];
     
+	if([args length]> 1)
+	{
+        	NSString* isCVVtoShow =[args objectAtIndex:1];
+	        if([isCVVtoShow isEqualToString:@"N"])
+        	    scanViewController.collectCVV= NO;
+	        else if([isCVVtoShow isEqualToString:@"Y"])
+        	    scanViewController.collectCVV= YES;
+	}	
+	
     [[TiApp app] showModalController:scanViewController animated:YES];
 }
 


### PR DESCRIPTION
Support for Managing (Showing / Hiding ) cvv field on Credit card details input View. This feature is require since some payment method do not require cvv field to be capture.
Form Titanium now user can call function in following way.
.scancard(callbackFunction); // Will show cvv field on Credit
.scancard(callbackFunction,'N'); // Will Hide cvv field on Credit
.scancard(callbackFunction,'Y'); // Will Show cvv field on Credit