### PR TITLE
build fixes, raising sdk to 6+ again

### DIFF
--- a/android/build.xml
+++ b/android/build.xml
@@ -1,4 +1,4 @@
-<project name="card.io" default="dist">
+<project name="cardio" default="dist">
 	<description>
 		Ant build script for Titanium Android module Card.io
 	</description>

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.0.4
+version: 2.0.5
 apiversion: 3
 architectures: armeabi-v7a x86
 description: Appcelerator wrapper for the Card.io credit card scanning library. Use the phone's camera to read credit card numbers and expiration dates.
@@ -11,8 +11,8 @@ license: Free
 copyright: Copyright (c) 2015 by Likely Solutions
 
 # these should not be edited
-name: Card.io
+name: cardio
 moduleid: com.likelysoft.cardio
 guid: c0304131-9611-4fff-9f83-f48bc9fa1714
 platform: android
-minsdk: 5.5.1.GA
+minsdk: 6.0.0.GA


### PR DESCRIPTION
Binary at: https://github.com/m1ga/Appcelerator-CardIO/releases/tag/2.0.5